### PR TITLE
Updated Dockerfile to use centos:8 image and added some missing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM centos:7
+FROM centos:8
 
-RUN yum install -y epel-release gcc git krb5-devel python-devel python2 python3
-RUN yum install -y python-pip
-RUN pip install --upgrade pip ; pip install --upgrade setuptools
-RUN pip install koji
+RUN yum install -y epel-release @python27 @python36
+RUN yum install -y gcc git jq krb5-devel openssl-devel libcurl-devel rpm-devel \
+    python{2,3}-{devel,pip}
+
+# Those environment variables are required to install pycurl, koji, and rpkg with pip
+ENV PYCURL_SSL_LIBRARY=openssl RPM_PY_SYS=true
+
+RUN pip2 install koji
 RUN pip3 install tox twine setuptools wheel codecov
-RUN curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output jq \
-    && chmod +x jq && mv jq /usr/local/bin/jq
-
-RUN pip install rh-doozer==0.5.17 rh-elliott==0.2.12 rh-ocp-build-data-validator==0.0.8
+RUN pip2 install rh-doozer==0.5.17 rh-elliott==0.2.12 rh-ocp-build-data-validator==0.0.8
 
 RUN useradd -ms /bin/bash -u 1000 art
 USER art


### PR DESCRIPTION
Also `libcurl-devel` is required by https://github.com/openshift/elliott/pull/62.