### PR TITLE
Add libgit2 as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 FROM centos:8
 
 RUN yum install -y epel-release @python27 @python36
-RUN yum install -y gcc git jq krb5-devel openssl-devel libcurl-devel rpm-devel \
-    python{2,3}-{devel,pip}
+RUN yum install -y \
+  gcc \
+  git \
+  jq \
+  krb5-devel \
+  libcurl-devel \
+  libgit2 \
+  openssl-devel \
+  rpm-devel \
+  python{2,3}-{devel,pip}
 
 # Those environment variables are required to install pycurl, koji, and rpkg with pip
 ENV PYCURL_SSL_LIBRARY=openssl RPM_PY_SYS=true


### PR DESCRIPTION
...and forego errors like:

```
  building '_pygit2' extension
  ...
  src/blob.h:33:10: fatal error: git2.h: No such file or directory
   #include <git2.h>
            ^~~~~~~~
```
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/art-tools/job/elliott/view/change-requests/job/PR-99/1/console