### PR TITLE
Ignore deleted files in test

### DIFF
--- a/vars/ocpBuildDataCISteps.groovy
+++ b/vars/ocpBuildDataCISteps.groovy
@@ -9,7 +9,7 @@ def call() {
 
         modifiedFiles = sh(
             returnStdout: true,
-            script: "git diff --name-only \$(git ls-remote origin --tags ${env.CHANGE_TARGET} | cut -f1) ${env.GIT_COMMIT}"
+            script: "git diff --name-only --diff-filter=ACMR \$(git ls-remote origin --tags ${env.CHANGE_TARGET} | cut -f1) ${env.GIT_COMMIT}"
         ).trim().split("\n").findAll { it.endsWith(".yml") }.findAll { !(it in ignoredFiles) }
 
         if ("group.yml" in modifiedFiles || "streams.yml" in modifiedFiles) {


### PR DESCRIPTION
When a file is deleted, the validator crashes. This ensures that files
are listed that are:
- A: Added
- C: Copied
- M: Modified
- R: Renamed

Not listed are files that are:
- D: Deleted
- T: Have file type change (symlinks etc)
- U: Are unmerged
- X: Unknown
- B: Broken