### PR TITLE
[ART-5074] add remove/add CI label function

### DIFF
--- a/vars/addCILabel.groovy
+++ b/vars/addCILabel.groovy
@@ -1,0 +1,24 @@
+import groovy.json.JsonOutput
+def call() {
+    withCredentials([string(credentialsId: "openshift-bot-token", variable: "GITHUB_TOKEN")]) {
+        script {
+            requestBody = JsonOutput.toJson([
+                'labels': ['art-bot-ci-passed']
+            ])
+            repositoryName = env.GIT_URL.replace("https://github.com/", "").replace(".git", "")
+
+            httpRequest(
+                contentType: 'APPLICATION_JSON',
+                customHeaders: [[
+                    maskValue: true,
+                    name: 'Authorization',
+                    value: "token ${env.GITHUB_TOKEN}"
+                ]],
+                httpMode: 'POST',
+                requestBody: requestBody,
+                responseHandle: 'NONE',
+                url: "https://api.github.com/repos/${repositoryName}/issues/${env.CHANGE_ID}/labels"
+            )
+        }
+    }
+}

--- a/vars/ocpBuildDataCISteps.groovy
+++ b/vars/ocpBuildDataCISteps.groovy
@@ -26,6 +26,11 @@ def call() {
 
         results = readFile("results.txt").trim()
         echo results
-        commentOnPullRequest(msg: "### Build <span>#</span>${env.BUILD_NUMBER}\n```\n${results}\n```")
+        if (env.CHANGE_ID) {
+        if (results =~ /commands succeeded/) {
+            addCILabel()
+        } else {
+            removeCILabel()
+        }
     }
 }

--- a/vars/removeCILabel.groovy
+++ b/vars/removeCILabel.groovy
@@ -1,0 +1,20 @@
+import groovy.json.JsonOutput
+def call() {
+    withCredentials([string(credentialsId: "openshift-bot-token", variable: "GITHUB_TOKEN")]) {
+        script {
+            repositoryName = env.GIT_URL.replace("https://github.com/", "").replace(".git", "")
+
+            httpRequest(
+                contentType: 'APPLICATION_JSON',
+                customHeaders: [[
+                    maskValue: true,
+                    name: 'Authorization',
+                    value: "token ${env.GITHUB_TOKEN}"
+                ]],
+                httpMode: 'DELETE',
+                responseHandle: 'NONE',
+                url: "https://api.github.com/repos/${repositoryName}/issues/${env.CHANGE_ID}/labels/art-bot-ci-passed"
+            )
+        }
+    }
+}


### PR DESCRIPTION
add `addCILabel` function and `removeCILabel` function
it can be used in CI job when test passed, like call this after test complete
```
if (env.CHANGE_ID) {
    if (results =~ /commands succeeded/) {
        addCILabel()
    } else {
        removeCILabel()
    }
}
```
bot can add the label like https://github.com/openshift/elliott/pull/468#event-7889925506 when CI test passed